### PR TITLE
Add teacher admin mode for activity signups/unregister

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,10 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login for admin mode
+- Teachers can sign up students for activities
+- Teachers can unregister students from activities
+- Students can still view activity rosters in read-only mode
 
 ## Getting Started
 
@@ -30,7 +33,11 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Teacher login with `username` and `password`                       |
+| GET    | `/auth/me`                                                        | Validate current teacher session (`X-Teacher-Token` header)        |
+| POST   | `/auth/logout`                                                    | Logout teacher session (`X-Teacher-Token` header)                  |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student (teacher only)                                  |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student (teacher only)                            |
 
 ## Data Model
 
@@ -48,3 +55,12 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Teacher Accounts
+
+Teacher usernames and passwords are stored in `teachers.json` and checked by the backend.
+
+Default sample credentials:
+
+- `teacher.alex` / `mergington123`
+- `teacher.jamie` / `classroom456`

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import secrets
 from pathlib import Path
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +21,36 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Teacher credentials are stored in a json file, while sessions stay in memory.
+teachers_file = current_dir / "teachers.json"
+teacher_sessions = {}
+
+
+class TeacherLoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teachers() -> dict:
+    if not teachers_file.exists():
+        return {}
+
+    with open(teachers_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    teachers = data.get("teachers", [])
+    return {
+        teacher["username"]: teacher["password"]
+        for teacher in teachers
+        if "username" in teacher and "password" in teacher
+    }
+
+
+def require_teacher_session(token: str | None) -> str:
+    if not token or token not in teacher_sessions:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+    return teacher_sessions[token]
 
 # In-memory activity database
 activities = {
@@ -88,9 +121,39 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(payload: TeacherLoginRequest):
+    teachers = load_teachers()
+    if payload.username not in teachers or teachers[payload.username] != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    token = secrets.token_urlsafe(24)
+    teacher_sessions[token] = payload.username
+    return {"token": token, "username": payload.username}
+
+
+@app.get("/auth/me")
+def teacher_me(x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")):
+    username = require_teacher_session(x_teacher_token)
+    return {"username": username}
+
+
+@app.post("/auth/logout")
+def teacher_logout(x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")):
+    require_teacher_session(x_teacher_token)
+    teacher_sessions.pop(x_teacher_token, None)
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")
+):
     """Sign up a student for an activity"""
+    teacher_username = require_teacher_session(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -105,14 +168,30 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate activity still has available spots
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {
+        "message": f"Signed up {email} for {activity_name}",
+        "teacher": teacher_username
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")
+):
     """Unregister a student from an activity"""
+    teacher_username = require_teacher_session(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -129,4 +208,7 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Remove student
     activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    return {
+        "message": f"Unregistered {email} from {activity_name}",
+        "teacher": teacher_username
+    }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,131 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const TOKEN_STORAGE_KEY = "teacherToken";
+  const USERNAME_STORAGE_KEY = "teacherUsername";
+
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const teacherOnlyNote = document.getElementById("teacher-only-note");
+
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const userMenu = document.getElementById("user-menu");
+  const teacherStatus = document.getElementById("teacher-status");
+  const loginMenuBtn = document.getElementById("login-menu-btn");
+  const logoutMenuBtn = document.getElementById("logout-menu-btn");
+
+  const loginModal = document.getElementById("login-modal");
+  const loginCloseBtn = document.getElementById("login-close-btn");
+  const teacherLoginForm = document.getElementById("teacher-login-form");
+  const teacherUsernameInput = document.getElementById("teacher-username");
+  const teacherPasswordInput = document.getElementById("teacher-password");
+
+  let teacherToken = localStorage.getItem(TOKEN_STORAGE_KEY) || "";
+  let teacherUsername = localStorage.getItem(USERNAME_STORAGE_KEY) || "";
+
+  function showMessage(text, style) {
+    messageDiv.textContent = text;
+    messageDiv.className = style;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function setTeacherAuth(enabled) {
+    const controls = signupForm.querySelectorAll("input, select, button");
+    controls.forEach((control) => {
+      control.disabled = !enabled;
+    });
+
+    if (enabled) {
+      teacherOnlyNote.textContent = `Teacher mode enabled (${teacherUsername}). You can register and unregister students.`;
+    } else {
+      teacherOnlyNote.textContent =
+        "Teachers must log in to register or unregister students.";
+    }
+  }
+
+  function updateAuthUI() {
+    const loggedIn = Boolean(teacherToken);
+
+    teacherStatus.textContent = loggedIn
+      ? `Teacher: ${teacherUsername}`
+      : "Student view";
+    loginMenuBtn.classList.toggle("hidden", loggedIn);
+    logoutMenuBtn.classList.toggle("hidden", !loggedIn);
+    setTeacherAuth(loggedIn);
+  }
+
+  function setLoggedOutState() {
+    teacherToken = "";
+    teacherUsername = "";
+    localStorage.removeItem(TOKEN_STORAGE_KEY);
+    localStorage.removeItem(USERNAME_STORAGE_KEY);
+    updateAuthUI();
+  }
+
+  async function ensureTeacherSession() {
+    if (!teacherToken) {
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+
+      if (!response.ok) {
+        setLoggedOutState();
+        return;
+      }
+
+      const payload = await response.json();
+      teacherUsername = payload.username;
+      localStorage.setItem(USERNAME_STORAGE_KEY, teacherUsername);
+    } catch (error) {
+      console.error("Error validating teacher session:", error);
+      setLoggedOutState();
+      showMessage("Failed to validate teacher session.", "error");
+    }
+
+    updateAuthUI();
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+    teacherUsernameInput.focus();
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    teacherLoginForm.reset();
+  }
+
+  async function handleTeacherLogout() {
+    if (!teacherToken) {
+      return;
+    }
+
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+    } catch (error) {
+      console.error("Error during logout:", error);
+    }
+
+    setLoggedOutState();
+    fetchActivities();
+    showMessage("Logged out.", "success");
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +135,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +155,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        teacherToken
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +186,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (teacherToken) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +200,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!teacherToken) {
+      showMessage("Only logged-in teachers can unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,32 +216,28 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          setLoggedOutState();
+          fetchActivities();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +245,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!teacherToken) {
+      showMessage("Only logged-in teachers can register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +261,98 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          setLoggedOutState();
+          fetchActivities();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  loginMenuBtn.addEventListener("click", () => {
+    userMenu.classList.add("hidden");
+    openLoginModal();
+  });
+
+  logoutMenuBtn.addEventListener("click", () => {
+    userMenu.classList.add("hidden");
+    handleTeacherLogout();
+  });
+
+  loginCloseBtn.addEventListener("click", closeLoginModal);
+
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
+  teacherLoginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = teacherUsernameInput.value.trim();
+    const password = teacherPasswordInput.value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      teacherToken = result.token;
+      teacherUsername = result.username;
+      localStorage.setItem(TOKEN_STORAGE_KEY, teacherToken);
+      localStorage.setItem(USERNAME_STORAGE_KEY, teacherUsername);
+      closeLoginModal();
+      updateAuthUI();
+      fetchActivities();
+      showMessage(`Teacher ${teacherUsername} logged in.`, "success");
+    } catch (error) {
+      showMessage("Unable to login right now. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!event.target.closest("#teacher-auth")) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
   // Initialize app
+  ensureTeacherSession();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="teacher-auth" class="teacher-auth">
+      <button id="user-menu-btn" class="icon-btn" aria-label="Teacher menu">👤</button>
+      <div id="user-menu" class="user-menu hidden">
+        <p id="teacher-status" class="teacher-status">Student view</p>
+        <button id="login-menu-btn" class="menu-btn" type="button">Teacher Login</button>
+        <button id="logout-menu-btn" class="menu-btn hidden" type="button">Logout</button>
+      </div>
+    </div>
+
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
@@ -23,6 +32,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info">Teachers must log in to register or unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +50,26 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Teacher Login</h3>
+          <button id="login-close-btn" class="close-btn" type="button">&times;</button>
+        </div>
+        <form id="teacher-login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -15,6 +15,46 @@ body {
   background-color: #f5f5f5;
 }
 
+.teacher-auth {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+}
+
+.icon-btn {
+  border: none;
+  border-radius: 999px;
+  width: 44px;
+  height: 44px;
+  font-size: 20px;
+  cursor: pointer;
+  background-color: #ffffff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  color: #1a237e;
+}
+
+.user-menu {
+  margin-top: 8px;
+  width: 220px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  padding: 12px;
+}
+
+.teacher-status {
+  margin: 0 0 8px;
+  font-size: 14px;
+  color: #555;
+}
+
+.menu-btn {
+  width: 100%;
+  margin-top: 6px;
+}
+
 header {
   text-align: center;
   padding: 20px 0;
@@ -162,6 +202,44 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+button:disabled,
+input:disabled,
+select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal-content {
+  width: min(92vw, 420px);
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.close-btn {
+  width: auto;
+  padding: 4px 10px;
+  font-size: 22px;
+  line-height: 1;
 }
 
 .message {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher.alex",
+      "password": "mergington123"
+    },
+    {
+      "username": "teacher.jamie",
+      "password": "classroom456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements Admin Mode to prevent students from removing each other.

## What changed
- Added teacher authentication endpoints (`/auth/login`, `/auth/me`, `/auth/logout`)
- Restricted activity signup/unregister endpoints to authenticated teachers
- Added `teachers.json` for teacher credentials (per issue requirement)
- Added top-right user icon with login/logout menu
- Added teacher login modal in frontend
- Disabled signup form and unregister buttons for non-logged-in users
- Updated docs with new endpoints and sample credentials

## Behavior
- Teachers (logged in) can register/unregister students
- Students (not logged in) can only view participants

Closes #5
